### PR TITLE
include libfranka>0.15.0 dependency (pinocchio)

### DIFF
--- a/cmake/FetchContent.cmake
+++ b/cmake/FetchContent.cmake
@@ -1,7 +1,5 @@
-list(APPEND CMAKE_PREFIX_PATH "/opt/openrobots/lib/cmake")
-
 find_package(Eigen3 REQUIRED)
-find_package(pinocchio REQUIRED)
+# find_package(pinocchio REQUIRED)  #lifranka > 0.15
 
 message("################################## ENTERING FETCHCONTENT FILE ##################################")
 if(NOT TARGET Eigen3::Eigen3)
@@ -16,26 +14,41 @@ endif()
 include(FetchContent)
 set(FETCHCONTENT_QUIET OFF)
 set(FETCHCONTENT_BASE_DIR ${CMAKE_SOURCE_DIR}/_deps)
+set(BUILD_EXAMPLES OFF CACHE INTERNAL "No examples")  # needed for libfranka version > 0.15 
+set(BUILD_TESTS OFF CACHE INTERNAL "No examples")
+set(BUILD_DOCUMENTATION OFF CACHE BOOL "Disable documentation")
+set(BUILD_PYTHON_INTERFACE OFF CACHE BOOL "Disable Python bindings")  # neglet eigenpy of pinocchio
+
+FetchContent_Declare(
+    pinocchio
+    GIT_REPOSITORY https://github.com/stack-of-tasks/pinocchio.git
+    GIT_TAG        v3.8.0
+    GIT_SUBMODULES ""
+    )
+FetchContent_MakeAvailable(pinocchio)
+FetchContent_GetProperties(pinocchio)
+#list(APPEND CMAKE_PREFIX_PATH ${pinocchio_BINARY_DIR})  # so libfranka can find pinocchio
+set(pinocchio_DIR ${pinocchio_BINARY_DIR}/cmake CACHE PATH "Direct path to pinocchio build config") # so libfranka can find pinocchio
 
 FetchContent_Declare(
     libfranka
-    #GIT_REPOSITORY https://github.com/frankaemika/libfranka-release.git
+    #GIT_REPOSITORY https://github.com/frankarobotics/libfranka-release.git
+    GIT_REPOSITORY https://github.com/frankarobotics/libfranka.git
     #GIT_TAG upstream/0.9.2)
+    GIT_TAG upstream/0.17.0)
     #GIT_REPOSITORY https://github.com/frankaemika/libfranka-release.git
     #GIT_TAG upstream/0.5.0)
-    GIT_REPOSITORY https://github.com/frankarobotics/libfranka.git
-    GIT_TAG 0.15.3)
+    
     #GIT_REPOSITORY https://github.com/frankaemika/libfranka.git
     #GIT_TAG 0.13.6)
-set(BUILD_EXAMPLES OFF CACHE INTERNAL "No examples")
-set(BUILD_TESTS OFF CACHE INTERNAL "No examples")
+# list(APPEND CMAKE_PREFIX_PATH "/opt/openrobots/lib/cmake")  # libfranka >0.15
+
 
 FetchContent_Declare(
     mirmi_cpp_utils
-    GIT_REPOSITORY https://github.com/SchneiderROS/mirmi_utils
-    GIT_TAG v1.7.2)
+    GIT_REPOSITORY https://gitlab.lrz.de/mirmi-internal/mirmi_utils.git
+    GIT_TAG dev_samu)
 
 set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE INTERNAL "")
 
 FetchContent_MakeAvailable(libfranka mirmi_cpp_utils)
-

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,8 +1,23 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && \
-    apt-get install -y python3.10 libpython3.10
-RUN apt-get install -y --no-install-recommends python3-pip
+    apt-get install -y --no-install-recommends \
+    python3.10 \
+    libpython3.10 \
+    python3-pip \
+    fping \
+    curl \
+    gnupg \
+    lsb-release
+RUN mkdir -p /etc/apt/keyrings && \
+    curl http://robotpkg.openrobots.org/packages/debian/robotpkg.asc | tee /etc/apt/keyrings/robotpkg.asc && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/robotpkg.asc] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" | tee /etc/apt/sources.list.d/robotpkg.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    robotpkg-pinocchio && \
+    # Clean up apt caches to keep the image small
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN pip3 install -U setuptools
 RUN pip3 install -U numpy
 RUN pip3 install -U scipy
@@ -11,7 +26,9 @@ RUN pip3 install -U scikit-learn
 RUN pip3 install -U requests
 RUN pip3 install -U pyDOE scikit-optimize
 RUN pip3 install -U websockets
-RUN apt-get install -y fping
+
+
+
 COPY mios/ /mios/
 COPY dependencies/ /dependencies/
 
@@ -25,6 +42,7 @@ ENV verbosity=$default_verbosity_value
 ENV database_port=$default_database_port_value
 ENV robot_config=$default_robot_config_value
 ENV robot_arm=$default_robot_arm_value
+ENV LD_LIBRARY_PATH=/opt/openrobots/lib:/dependencies:/mios/lib:$LD_LIBRARY_PATH
 
 WORKDIR mios/bin
 CMD ["sh", "-c", "./mios.sh --verbosity=${verbosity} --database_port=${database_port} --robot_config=${robot_config} --robot_arm=${robot_arm}"]

--- a/utils/mios.sh
+++ b/utils/mios.sh
@@ -5,6 +5,6 @@ PYTHONPATH=$PYTHONPATH:${ROOT}/../python/desk:${ROOT}/../ml_service:/usr/local/l
 export PYTHONPATH
 #export ROS_MASTER_URI=http://localhost:11311
 unset LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${ROOT}/../lib:${ROOT}/../lib/boost:${ROOT}/../lib/plugins:${ROOT}/../../dependencies  # ${ROOT}/../lib/boost:/opt/ros/noetic/lib:
+export LD_LIBRARY_PATH=${ROOT}/../lib:${ROOT}/../lib/boost:${ROOT}/../lib/plugins:${ROOT}/../../dependencies:/opt/openrobots/lib      #ROS ${ROOT}/../lib/boost:/opt/ros/noetic/lib:
 exec ${ROOT}/mios $@
 exit 0


### PR DESCRIPTION
For the usage of mios with the new FR3 robot, the libfranka version was updated to 0.17.0. Libfranka version > 0.15.0 have pinocchio as dependency. Assuming a system wide install of pinocchio, the cmake files and mios.sh are adapted and the dockerfile for building the mios core image was extended to also install pinocchio.