### PR TITLE
remove all-related Data Buffer functions and variables

### DIFF
--- a/ml_service/interface/interface.py
+++ b/ml_service/interface/interface.py
@@ -132,7 +132,7 @@ class Interface:
             if self.service.initialize(problem_definition, configuration, agents, knowledge,info) is False:
                 return False
             logger.debug("Service initialized ")
-            self.telemetry_buffer = self.service.data_buffer_visualization
+            self.telemetry_buffer = None
             result = self.service.learn_task()
             logger.debug("learning success " + str(result))
         finally:
@@ -245,8 +245,8 @@ class Interface:
     def stop_telemetry(self):
         self.keep_running_telemetry = False
         logger.debug("interface::stop_telemetry"+str(self.keep_running_telemetry))
-        if self.service is not None:
-            self.service.data_buffer_visualization.add_data("STOP")
+        # if self.service is not None:
+        #     self.service.data_buffer_visualization.add_data("STOP")
         if self.telemetry_thread is not None:
             self.telemetry_thread.join()
             self.telemetry_thread = None

--- a/ml_service/services/base_service.py
+++ b/ml_service/services/base_service.py
@@ -76,7 +76,7 @@ class BaseService(metaclass=ABCMeta):
         self.similarity_estimate = {}  # this maps a similarity to all collective agents 
         self.external_success = {}     # will be filled for each external Task with 1 for success or 0 if not
         self.internal_success = []     # counts just the internal trials: 1 for success 0 for failure
-        self.data_buffer_visualization = DataBuffer()
+        # self.data_buffer_visualization = DataBuffer()
         self.test_debug = 0
         self.delta_time = 0
         self.starting_time = time.time()
@@ -106,7 +106,7 @@ class BaseService(metaclass=ABCMeta):
         self.configuration = configuration
         self.info=info
         #self.knowledge_source = knowledge_source
-        self.data_buffer_visualization = DataBuffer()
+        #self.data_buffer_visualization = DataBuffer()
         if knowledge_source is not None:
             self.knowledge.from_dict(knowledge_source)
         self.starting_time = time.time()  # starting time of learning before first trial (used to retrief knowledge)
@@ -351,7 +351,7 @@ class BaseService(metaclass=ABCMeta):
         if result_dict["external"]:  # if external is not False
             if type(result_dict["external"]) is str:
                 result_dict["external"] = eval(result_dict["external"])  # make it a dict again from string
-        self.data_buffer_visualization.add_data(self.make_float_again(result_dict))
+        # self.data_buffer_visualization.add_data(self.make_float_again(result_dict))
         return result.task_result
 
     def get_theta(self, x) -> dict:


### PR DESCRIPTION
Dear @SchneiderROS ,

As we found that the latest codebase shows no error in Build time, we also found that it shows error during Runtime.

The error message was

```
DataBuffer' is not defined
```

and I believe it is related to removal of `rpc_visualization` folder

## Proposed Solution

as seen below, we need to slightly modify `base_service.py` and `interface.py`

<img width="1246" height="899" alt="image" src="https://github.com/user-attachments/assets/d63f6353-c8a2-43d2-a7e2-d34e94b36c99" />


## Full Error Log

```
  File "/home/ubuntu/janine/samuel/mios/ml_service/example_learning.py", line 110, in <module>
    example_learning()
  File "/home/ubuntu/janine/samuel/mios/ml_service/example_learning.py", line 97, in example_learning
    learn_task(robot, pd, sc, tags, knowledge=knowledge, n_iterations=1,service_port=8000,wait=True)
  File "/home/ubuntu/janine/samuel/mios/ml_service/example_learning.py", line 15, in learn_task
    start_experiment(robot, [robot], problem_definition, service_config, n_iterations, knowledge=knowledge, tags=tags,
  File "/home/ubuntu/janine/samuel/mios/ml_service/utils/experiment_wizard.py", line 37, in start_experiment
    uuid = s.start_service(problem_def.to_dict(), service.to_dict(), agents, knowledge)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/xmlrpc/client.py", line 1122, in __call__
    return self.__send(self.__name, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/xmlrpc/client.py", line 1461, in __request
    response = self.__transport.request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/xmlrpc/client.py", line 1166, in request
    return self.single_request(host, handler, request_body, verbose)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/xmlrpc/client.py", line 1182, in single_request
    return self.parse_response(resp)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/xmlrpc/client.py", line 1351, in parse_response
    return u.close()
           ^^^^^^^^^
  File "/usr/lib/python3.12/xmlrpc/client.py", line 668, in close
    raise Fault(**self._stack[0])
xmlrpc.client.Fault: <Fault 1: "<class 'NameError'>:name 'DataBuffer' is not defined">
```

