### PR TITLE
Overhaul mios parameters

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -3,21 +3,24 @@ services:
     image: "mirmi/mios:FR3"
     restart: always
     environment:
-      - ROBOT_IP=192.168.3.100
+      - verbosity=debug
+      - robot_ip=192.168.3.100
       - ROBOT_USER=MBZUAI
       - ROBOT_PASSWORD=mbzuai123
-      - MONGONAME=miosL
-      - verbosity=debug
+      - database_name=miosL
       - database_port=27017
       - robot_config=0
-      - robot_arm=left
+      - desk=true
+      - websocket_port=12000
+      - rpc_port=12001
+      - udp_port=12002
     network_mode: "host"
     cap_add:
       - SYS_NICE
     depends_on:
       - "mongo"
   mongo:
-    image: "mongo:4.4.6"
+    image: "mongo:7.0.14"
     ports:
       - "27017:27017"
     volumes:
@@ -25,7 +28,7 @@ services:
     command: mongod --quiet --logpath /dev/null 
 
   mios_mls:
-    image: "mirmi/mios_mls:dualarm"
+    image: "mirmi/mios_mls:latest"
     ports:
       - "8000:8000"
       - "8001:8001"

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -40,13 +40,25 @@ EXPOSE 12000 12001 12002 8888 8889
 
 ARG default_verbosity_value=info
 ARG default_database_port_value=27017
-ARG default_robot_config_value=3
-ARG default_robot_arm_value=left
+ARG default_database_name=mios
+ARG default_robot_ip=127.0.0.1
+ARG default_websocket_port=12000
+ARG default_rpc_port=12001
+ARG default_udp_port=12002
+ARG default_robot_config_value=0
+ARG default_desk=true
+
 ENV verbosity=$default_verbosity_value
 ENV database_port=$default_database_port_value
-ENV robot_config=$default_robot_config_value
-ENV robot_arm=$default_robot_arm_value
+ENV database_name=$default_database_name
+ENV robot_ip=$default_robot_ip
+ENV websocket_port=$default_websocket_port
+ENV rpc_port=$default_rpc_port
+ENV udp_port=$default_udp_port
+ENV robot_config_value=$default_robot_config_value
+ENV desk=$default_desk
+
 ENV LD_LIBRARY_PATH=/opt/openrobots/lib:/dependencies:/mios/lib:$LD_LIBRARY_PATH
 
 WORKDIR mios/bin
-CMD ["sh", "-c", "bash ./mios.sh --verbosity=${verbosity} --database_port=${database_port} --robot_config=${robot_config} --robot_arm=${robot_arm}"]
+CMD ["bash", "./mios.sh"]

--- a/python/desk/config_loader.py
+++ b/python/desk/config_loader.py
@@ -23,7 +23,7 @@ if ROBOT_USER is None:
 ROBOT_PASSWORD = os.getenv("ROBOT_PASSWORD")
 if ROBOT_PASSWORD is None:
   ROBOT_PASSWORD = "<user-password>"
-MONGONAME = os.getenv("MONGONAME")
+MONGONAME = os.getenv("database_name")
 if MONGONAME is None:
   MONGONAME = "mios"
 

--- a/python/desk/config_loader.py
+++ b/python/desk/config_loader.py
@@ -14,7 +14,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 CONFIG_FILE = SCRIPT_DIR/'config.json'
 
-ROBOT_IP = os.getenv("ROBOT_IP")
+ROBOT_IP = os.getenv("robot_ip")
 if ROBOT_IP is None:
   ROBOT_IP = "127.0.0.1"
 ROBOT_USER = os.getenv("ROBOT_USER")
@@ -32,7 +32,7 @@ DEFAULT_CONFIG = {
     "robot_ip": "https://"+ROBOT_IP,
     "username": ROBOT_USER,
     "password": ROBOT_PASSWORD,
-    "mongo_name": MONGONAME,
+    "database_name": MONGONAME,
     "enable_proxy": False,
     "socks5_proxy": "socks5h://127.0.0.1:1080"
   },

--- a/python/desk/deskapi.py
+++ b/python/desk/deskapi.py
@@ -67,7 +67,9 @@ def save_token(token: str):
     """Saves the control token to MongoDB (mios->parameter->system)."""
 
     mongo_client = MongoDBClient("localhost",27017)
-    mongo_client.update(MONGONAME,"parameters",{"name":"system"},{"spoc_token":token})
+    result = mongo_client.update(MONGONAME,"parameters",{"name":"system"},{"spoc_token":token}, upsert=True)
+    if not result:
+        print(f"Cannot update the token onto MongoDB.", flush=True)
 
 
 def load_token() -> Optional[str]:

--- a/python/desk/deskapi.py
+++ b/python/desk/deskapi.py
@@ -25,7 +25,7 @@ api_config = config['api_settings']
 ROBOT_IP = api_config['robot_ip']
 USERNAME = api_config['username']
 PASSWORD = api_config['password']
-MONGONAME = api_config['mongo_name']
+MONGONAME = api_config['database_name']
 ENABLE_PROXY = api_config['enable_proxy']
 SOCKS5_PROXY = api_config['socks5_proxy']
 

--- a/python/desk/mongodb_client.py
+++ b/python/desk/mongodb_client.py
@@ -83,7 +83,7 @@ class MongoDBClient():
         else:
             return False
 
-    def update(self, db: str, collection: str, search_param: dict, new_param: dict) -> bool:
+    def update(self, db: str, collection: str, search_param: dict, new_param: dict, upsert: bool = False) -> bool:
         db_connection = self.client[db]
         col = db_connection[collection]
         if isinstance(search_param, dict):
@@ -94,7 +94,7 @@ class MongoDBClient():
                 if new_param.get("_id", False):
                     new_param.pop("_id")
                 new_param_set = {"$set": new_param}
-                col.update_one(search_param, new_param_set, upsert=False)
+                col.update_one(search_param, new_param_set, upsert=upsert)
             else:
                 print("new parameter for update are not dict, but " + str(type(new_param)))
                 return False

--- a/src/core/include/mios/core/core.hpp
+++ b/src/core/include/mios/core/core.hpp
@@ -20,6 +20,7 @@
 
 #include "mios/data_structures/actuator.hpp"
 #include "mios/data_structures/percept.hpp"
+#include "mios/utils/configuration.hpp"
 
 
 
@@ -29,7 +30,7 @@ class Skill;
 
 class Core{
 public:
-    Core(unsigned database_port, unsigned robot_configuration, std::string robot_arm);
+    Core(const MiosConfiguration &configuration);
     ~Core();
 
     bool initialize();
@@ -104,9 +105,8 @@ private:
 
 private:
     bool m_is_ready;
-    unsigned m_robot_configuration;
+    MiosConfiguration m_configuration;
     bool m_blend_skill;
-    std::string m_robot_arm;
     std::mutex m_mtx_is_busy;
     std::mutex m_mtx_FCI;
 

--- a/src/core/include/mios/core/core.hpp
+++ b/src/core/include/mios/core/core.hpp
@@ -20,7 +20,7 @@
 
 #include "mios/data_structures/actuator.hpp"
 #include "mios/data_structures/percept.hpp"
-#include "mios/utils/configuration.hpp"
+#include "mios/utils/context.hpp"
 
 
 
@@ -30,7 +30,7 @@ class Skill;
 
 class Core{
 public:
-    Core(const MiosConfiguration &configuration);
+    Core(const MiosContext &context);
     ~Core();
 
     bool initialize();
@@ -75,7 +75,8 @@ public:
     TelemetryUDP* get_telemetry();
     const Percept *get_percept() const;
     bool is_ready() const;
-    bool is_busy();
+    bool is_busy();  
+    MiosContext m_context;
 
 private:
     franka::Finishable *control_base_cycle(const franka::RobotState& state);
@@ -105,7 +106,6 @@ private:
 
 private:
     bool m_is_ready;
-    MiosConfiguration m_configuration;
     bool m_blend_skill;
     std::mutex m_mtx_is_busy;
     std::mutex m_mtx_FCI;

--- a/src/core/src/core.cpp
+++ b/src/core/src/core.cpp
@@ -26,12 +26,22 @@
 
 namespace mios {
 
-Core::Core(unsigned database_port, unsigned robot_configuration, std::string robot_arm):m_memory(database_port, robot_arm),m_skill_engine(SkillEngine(this)),m_panda_body(PandaBody(&m_memory)),
-    m_portal(Portal("0.0.0.0",(robot_arm == "left") ? 12000 : 13000,"mios/core","0.0.0.0",(robot_arm == "left") ? 12001 : 13001,(robot_arm == "left") ? 12002 : 13002)),m_task_engine(TaskEngine(this)),
+Core::Core(const MiosConfiguration &configuration):
+    m_memory(configuration),
+    m_skill_engine(SkillEngine(this)),
+    m_panda_body(PandaBody(&m_memory)),
+    m_portal(Portal("0.0.0.0",configuration.websocket_port,"mios/core", //websocket
+                    "0.0.0.0",configuration.rpc_port,                   //rpc
+                    configuration.udp_port)),                           //udp
+    m_task_engine(TaskEngine(this)),
     m_command_interface(CommandInterface(this,&m_task_engine,&m_portal,&m_memory)),//m_ros_node(this,&m_task_engine,&m_portal,&m_memory),
-    m_telemetry(TelemetryUDP(this,&m_portal)),m_controller_pipeline(std::make_unique<NullControllerPipeline>()),m_is_ready(false),
-    m_robot_configuration(robot_configuration),m_robot_arm(robot_arm) ,m_blend_skill(false),m_hand_grace_period(0){
-    spdlog::trace("Core::Core()");
+    m_telemetry(TelemetryUDP(this,&m_portal)),
+    m_controller_pipeline(std::make_unique<NullControllerPipeline>()),
+    m_is_ready(false),
+    m_configuration(configuration),
+    m_blend_skill(false),
+    m_hand_grace_period(0){
+        spdlog::trace("Core::Core()");
 }
 
 Core::~Core(){
@@ -42,12 +52,12 @@ Core::~Core(){
 bool Core::initialize(){
     spdlog::trace("Core::initialize()");
     spdlog::info("Initializing memory...");
-    if(!m_memory.initialize(&m_skill_library,m_robot_configuration)){
+    if(!m_memory.initialize(&m_skill_library)){
         spdlog::error("Could not initialize memory.");
         return false;
     }
     spdlog::info("Initializing robot...");
-    if(!m_panda_body.initialize()){
+    if(!m_panda_body.initialize(m_configuration)){
         spdlog::error("Could not initialize robot.");
         return false;
     }
@@ -502,8 +512,8 @@ bool Core::refresh_percept(std::optional<Eigen::Matrix<double,3,3> > O_R_TF, boo
             if(count>6){
                 count = 0;
                 spdlog::debug("reconnecting to Robot and Gripper");
-                m_panda_body.connect_to_robot(m_memory.get_parameters()->system.robot_ip);
-                m_panda_body.connect_to_gripper(m_memory.get_parameters()->system.robot_ip);
+                m_panda_body.connect_to_robot(m_configuration.robot_ip);
+                m_panda_body.connect_to_gripper(m_configuration.robot_ip);
             }
             count++;
         }
@@ -511,7 +521,7 @@ bool Core::refresh_percept(std::optional<Eigen::Matrix<double,3,3> > O_R_TF, boo
         if(!m_panda_body.get_robot_state(robot_state)){
             spdlog::debug("Core::refresh_percept.failed_to_acquire_robot_state");
             spdlog::debug("reconnecting to Robot");
-            m_panda_body.connect_to_robot(m_memory.get_parameters()->system.robot_ip);
+            m_panda_body.connect_to_robot(m_configuration.robot_ip);
             if(!m_panda_body.get_robot_state(robot_state)){
                 return false;
             }
@@ -519,7 +529,7 @@ bool Core::refresh_percept(std::optional<Eigen::Matrix<double,3,3> > O_R_TF, boo
         if(!m_panda_body.get_gripper_state(gripper_state)){
             spdlog::debug("Core::refresh_percept.failed_to_acquire_gripper_state");
             spdlog::debug("reconnecting to Gripper");
-            m_panda_body.connect_to_gripper(m_memory.get_parameters()->system.robot_ip);
+            m_panda_body.connect_to_gripper(m_configuration.robot_ip);
             if(!m_panda_body.get_gripper_state(gripper_state)){
                 return false;
             }

--- a/src/core/src/core.cpp
+++ b/src/core/src/core.cpp
@@ -26,19 +26,19 @@
 
 namespace mios {
 
-Core::Core(const MiosConfiguration &configuration):
-    m_memory(configuration),
+Core::Core(const MiosContext &context):
+    m_memory(context),
     m_skill_engine(SkillEngine(this)),
-    m_panda_body(PandaBody(&m_memory)),
-    m_portal(Portal("0.0.0.0",configuration.websocket_port,"mios/core", //websocket
-                    "0.0.0.0",configuration.rpc_port,                   //rpc
-                    configuration.udp_port)),                           //udp
+    m_panda_body(PandaBody(&m_memory, context)),
+    m_portal(Portal("0.0.0.0",context.config.websocket_port,"mios/core", //websocket
+                    "0.0.0.0",m_context.config.rpc_port,                 //rpc
+                    context.config.udp_port)),                           //udp
     m_task_engine(TaskEngine(this)),
     m_command_interface(CommandInterface(this,&m_task_engine,&m_portal,&m_memory)),//m_ros_node(this,&m_task_engine,&m_portal,&m_memory),
     m_telemetry(TelemetryUDP(this,&m_portal)),
     m_controller_pipeline(std::make_unique<NullControllerPipeline>()),
     m_is_ready(false),
-    m_configuration(configuration),
+    m_context(context),
     m_blend_skill(false),
     m_hand_grace_period(0){
         spdlog::trace("Core::Core()");
@@ -57,7 +57,7 @@ bool Core::initialize(){
         return false;
     }
     spdlog::info("Initializing robot...");
-    if(!m_panda_body.initialize(m_configuration)){
+    if(!m_panda_body.initialize()){
         spdlog::error("Could not initialize robot.");
         return false;
     }
@@ -237,6 +237,9 @@ void Core::handle_gripper(Actuator* cmd){
 }
 
 franka::Finishable* Core::control_base_cycle(const franka::RobotState& state){
+    if(m_context.shutdown_signal){
+        terminate();
+    }
     bool exception=false;
     if(m_skill_engine.is_running_queue() && m_blend_skill){
         if(!m_skill_engine.blend_skill_stage_1()){
@@ -512,8 +515,8 @@ bool Core::refresh_percept(std::optional<Eigen::Matrix<double,3,3> > O_R_TF, boo
             if(count>6){
                 count = 0;
                 spdlog::debug("reconnecting to Robot and Gripper");
-                m_panda_body.connect_to_robot(m_configuration.robot_ip);
-                m_panda_body.connect_to_gripper(m_configuration.robot_ip);
+                m_panda_body.connect_to_robot(m_context.config.robot_ip);
+                m_panda_body.connect_to_gripper(m_context.config.robot_ip);
             }
             count++;
         }
@@ -521,7 +524,7 @@ bool Core::refresh_percept(std::optional<Eigen::Matrix<double,3,3> > O_R_TF, boo
         if(!m_panda_body.get_robot_state(robot_state)){
             spdlog::debug("Core::refresh_percept.failed_to_acquire_robot_state");
             spdlog::debug("reconnecting to Robot");
-            m_panda_body.connect_to_robot(m_configuration.robot_ip);
+            m_panda_body.connect_to_robot(m_context.config.robot_ip);
             if(!m_panda_body.get_robot_state(robot_state)){
                 return false;
             }
@@ -529,7 +532,7 @@ bool Core::refresh_percept(std::optional<Eigen::Matrix<double,3,3> > O_R_TF, boo
         if(!m_panda_body.get_gripper_state(gripper_state)){
             spdlog::debug("Core::refresh_percept.failed_to_acquire_gripper_state");
             spdlog::debug("reconnecting to Gripper");
-            m_panda_body.connect_to_gripper(m_configuration.robot_ip);
+            m_panda_body.connect_to_gripper(m_context.config.robot_ip);
             if(!m_panda_body.get_gripper_state(gripper_state)){
                 return false;
             }

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(mios
     ${PROJECT_NAME}::${PROJECT_NAME}_project_deps
     PUBLIC
     ${PROJECT_NAME}::core
+    ${PROJECT_NAME}::utils
     pybind11::pybind11
     cxxopts::cxxopts
     stdc++fs

--- a/src/main/src/mios.cpp
+++ b/src/main/src/mios.cpp
@@ -11,6 +11,7 @@
 
 #include "pybind11/pybind11.h"
 #include "mios/core/core.hpp"
+#include "mios/utils/configuration.hpp"
 #include "mirmi_cpp_utils/network/network.hpp"
 #include "cxxopts.hpp"
 #include "commons/config.hpp"
@@ -24,21 +25,31 @@ int main(int argc, char** argv){
     options.add_options()
             ("v,verbosity","Set level of verbosity.",cxxopts::value<std::string>()->default_value("info"))
             ("p,database_port","Port of mongodb database.",cxxopts::value<unsigned>()->default_value("27017"))
-            ("c,robot_config","Initial configuration of robot: 0 - arm and Franka Hand, 1 - only arm, 2 - arm and Softhand2, 3 - no arm and gripper.",cxxopts::value<unsigned>()->default_value("0"))
-            ("a,robot_arm", "left arm or right arm", cxxopts::value<std::string>()->default_value("left"));
+            ("n,database_name","Name of mongodb database.",cxxopts::value<std::string>()->default_value("mios"))
+            ("i,robot_ip","IPv4 of Robot ControlBox.",cxxopts::value<std::string>()->default_value("127.0.0.1"))
+            ("w,websocket_port","WebSocket Interface Port used by mios.",cxxopts::value<unsigned>()->default_value("12000"))
+            ("r,rpc_port","RPC Interface Port used by mios.",cxxopts::value<unsigned>()->default_value("12001"))
+            ("u,udp_port","UDP Interface Port used by mios.",cxxopts::value<unsigned>()->default_value("12002"))
+            ("c,robot_config","Initial configuration of robot: 0 - arm and Franka Hand, 1 - only arm, 2 - arm and Softhand2, 3 - no arm and gripper,  4 - libfranka-sim config (arm+FrankaHand) ,   - libfranka-sim config (only arm)",cxxopts::value<unsigned>()->default_value("0"));
+
 
     auto result = options.parse(argc, argv);
-    std::string verbosity=result["v"].as<std::string>();
-    unsigned database_port=result["p"].as<unsigned>();
-    unsigned robot_configuration=result["c"].as<unsigned>();
-    std::string robot_arm = result["a"].as<std::string>();
+    mios::MiosConfiguration configuration;
+    configuration.verbosity=result["v"].as<std::string>();
+    configuration.database_port=result["p"].as<unsigned>();
+    configuration.database_name=result["n"].as<std::string>();
+    configuration.robot_ip=result["i"].as<std::string>();
+    configuration.robot_configuration=result["c"].as<unsigned>();
+    configuration.rpc_port=result["r"].as<unsigned>();
+    configuration.udp_port=result["u"].as<unsigned>();
+    configuration.websocket_port=result["w"].as<unsigned>();
 
     spdlog::level::level_enum info_level;
-    if(verbosity=="trace"){
+    if(configuration.verbosity=="trace"){
         info_level=spdlog::level::trace;
-    }else if(verbosity=="debug"){
+    }else if(configuration.verbosity=="debug"){
         info_level=spdlog::level::debug;
-    }else if(verbosity=="info"){
+    }else if(configuration.verbosity=="info"){
         info_level=spdlog::level::info;
     }else{
         info_level=spdlog::level::info;
@@ -68,18 +79,17 @@ int main(int argc, char** argv){
     spdlog::info("MIOS");
     spdlog::info("Version: " + std::to_string(PROJECT_VERSION_MAJOR) + "." + std::to_string(PROJECT_VERSION_MINOR) + "." + std::to_string(PROJECT_VERSION_PATCH));
 
-    unsigned port = (robot_arm == "left")? 12000 : 13000;
-    if(!mirmi_utils::is_port_available("localhost",port)){
-        spdlog::error("Port "+std::to_string(port)+" is blocked by another process. You can check which process is blocking the port"
-                                                   "by typing 'netstat -ntlup | grep "+std::to_string(port)+"' in a terminal. Terminating...");
+    if(!mirmi_utils::is_port_available("localhost",configuration.websocket_port)){
+        spdlog::error("Port "+std::to_string(configuration.websocket_port)+" is blocked by another process. You can check which process is blocking the port"
+                                                   "by typing 'netstat -ntlup | grep "+std::to_string(configuration.websocket_port)+"' in a terminal. Terminating...");
         return -1;
     }
 
-    std::string RosName = (robot_arm == "left")? "miosL" : "miosR";
+    std::string RosName = configuration.database_name;
     //ros::init(argc, argv, RosName, ros::init_options::NoSigintHandler);
 
     pybind11::scoped_interpreter guard{};
-    mios::Core core(database_port,robot_configuration, robot_arm);
+    mios::Core core(configuration);
     spdlog::info("Initializing MIOS core...");
     if(!core.initialize()){
         spdlog::error("MIOS core could not be initialized, shutting down...");

--- a/src/main/src/mios.cpp
+++ b/src/main/src/mios.cpp
@@ -8,16 +8,36 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/fmt/ostr.h"
 
 #include "pybind11/pybind11.h"
 #include "mios/core/core.hpp"
+#include "mios/utils/context.hpp"
 #include "mios/utils/configuration.hpp"
 #include "mirmi_cpp_utils/network/network.hpp"
 #include "cxxopts.hpp"
 #include "commons/config.hpp"
 
-void exit_handler(int s);
+// Global control flags
+std::atomic<bool> shutdown_signal{false};
+std::atomic<int> signal_count{0};
 
+void exit_handler(int signum) {
+    int count = ++signal_count;
+    if (count == 1) {
+        // --- FIRST SIGNAL: GRACEFUL ---
+        shutdown_signal = true;
+        const char* msg = "\n[SIG] Shutdown signal received. Cleaning up...\n"
+                          "[SIG] Press Ctrl+C again to FORCE kill immediately.\n";
+        write(STDERR_FILENO, msg, 84); 
+    } 
+    else {
+        // --- SECOND SIGNAL: FORCE KILL ---
+        const char* msg = "\n[SIG] Force quitting!\n";
+        write(STDERR_FILENO, msg, 21);
+        std::_Exit(EXIT_FAILURE); 
+    }
+}
 
 int main(int argc, char** argv){
 
@@ -30,7 +50,8 @@ int main(int argc, char** argv){
             ("w,websocket_port","WebSocket Interface Port used by mios.",cxxopts::value<unsigned>()->default_value("12000"))
             ("r,rpc_port","RPC Interface Port used by mios.",cxxopts::value<unsigned>()->default_value("12001"))
             ("u,udp_port","UDP Interface Port used by mios.",cxxopts::value<unsigned>()->default_value("12002"))
-            ("c,robot_config","Initial configuration of robot: 0 - arm and Franka Hand, 1 - only arm, 2 - arm and Softhand2, 3 - no arm and gripper,  4 - libfranka-sim config (arm+FrankaHand) ,   - libfranka-sim config (only arm)",cxxopts::value<unsigned>()->default_value("0"));
+            ("c,robot_config","Initial configuration of robot: 0 - arm and Franka Hand, 1 - only arm, 2 - arm and Softhand2, 3 - no arm and gripper",cxxopts::value<unsigned>()->default_value("0"))
+            ("d,desk","Disable DESK interface usage",cxxopts::value<std::string>()->default_value("true"));
 
 
     auto result = options.parse(argc, argv);
@@ -43,6 +64,8 @@ int main(int argc, char** argv){
     configuration.rpc_port=result["r"].as<unsigned>();
     configuration.udp_port=result["u"].as<unsigned>();
     configuration.websocket_port=result["w"].as<unsigned>();
+    std::string use_desk = result["d"].as<std::string>();
+    configuration.use_desk=(use_desk == "true" || use_desk == "True" || use_desk == "1");
 
     spdlog::level::level_enum info_level;
     if(configuration.verbosity=="trace"){
@@ -73,11 +96,13 @@ int main(int argc, char** argv){
     sigIntHandler.sa_handler = exit_handler;
     sigemptyset(&sigIntHandler.sa_mask);
     sigIntHandler.sa_flags = 0;
-    sigaction(SIGINT, &sigIntHandler, NULL);
+    sigaction(SIGINT, &sigIntHandler, NULL);    // catch stop signal form crtl+c
+    sigaction(SIGTERM, &sigIntHandler, NULL);   // catch stop signal from docker stop
 
     spdlog::info("############################################################");
     spdlog::info("MIOS");
     spdlog::info("Version: " + std::to_string(PROJECT_VERSION_MAJOR) + "." + std::to_string(PROJECT_VERSION_MINOR) + "." + std::to_string(PROJECT_VERSION_PATCH));
+    spdlog::info("Initial configuration:\n{}", configuration);
 
     if(!mirmi_utils::is_port_available("localhost",configuration.websocket_port)){
         spdlog::error("Port "+std::to_string(configuration.websocket_port)+" is blocked by another process. You can check which process is blocking the port"
@@ -89,7 +114,9 @@ int main(int argc, char** argv){
     //ros::init(argc, argv, RosName, ros::init_options::NoSigintHandler);
 
     pybind11::scoped_interpreter guard{};
-    mios::Core core(configuration);
+
+    MiosContext context { configuration, shutdown_signal };
+    mios::Core core(context);
     spdlog::info("Initializing MIOS core...");
     if(!core.initialize()){
         spdlog::error("MIOS core could not be initialized, shutting down...");
@@ -102,7 +129,3 @@ int main(int argc, char** argv){
     return 0;
 }
 
-void exit_handler(int s){
-    printf("Caught exit signal %i, terminating server.",s);
-    exit(0);
-}

--- a/src/memory/include/mios/memory/lt_memory.hpp
+++ b/src/memory/include/mios/memory/lt_memory.hpp
@@ -3,6 +3,7 @@
 #include "mios/mongodb_client/mongodb_client.hpp"
 #include "mios/data_structures/object.hpp"
 #include "mios/data_structures/task_data.hpp"
+#include "mios/utils/configuration.hpp"
 
 #include "nlohmann/json.hpp"
 
@@ -20,11 +21,11 @@ class SkillLibrary;
 
 class LTMemory{
 public:
-    LTMemory(unsigned database_port, std::string robot_arm);
+    LTMemory(const MiosConfiguration &configuration);
     bool is_ok() const;
     void link_to_st_memory(STMemory* st_memory);
     void link_to_skill_library(SkillLibrary* skill_library);
-    bool initialize(unsigned robot_configuration);
+    bool initialize();
     bool load_default_parameters(nlohmann::json &parameters);
 
     bool get_task_data(const std::string uuid,TaskData& data) const;
@@ -41,7 +42,7 @@ public:
     bool upload_log_element(const nlohmann::json& log_entry);
     bool update_database();
 
-    unsigned m_database_port;
+    MiosConfiguration m_configuration;
 
 private:
     bool make_database_consistent();

--- a/src/memory/include/mios/memory/lt_memory.hpp
+++ b/src/memory/include/mios/memory/lt_memory.hpp
@@ -3,7 +3,7 @@
 #include "mios/mongodb_client/mongodb_client.hpp"
 #include "mios/data_structures/object.hpp"
 #include "mios/data_structures/task_data.hpp"
-#include "mios/utils/configuration.hpp"
+#include "mios/utils/context.hpp"
 
 #include "nlohmann/json.hpp"
 
@@ -21,7 +21,7 @@ class SkillLibrary;
 
 class LTMemory{
 public:
-    LTMemory(const MiosConfiguration &configuration);
+    LTMemory(const MiosContext &context);
     bool is_ok() const;
     void link_to_st_memory(STMemory* st_memory);
     void link_to_skill_library(SkillLibrary* skill_library);
@@ -42,7 +42,7 @@ public:
     bool upload_log_element(const nlohmann::json& log_entry);
     bool update_database();
 
-    MiosConfiguration m_configuration;
+    MiosContext m_context;
 
 private:
     bool make_database_consistent();

--- a/src/memory/include/mios/memory/memory.hpp
+++ b/src/memory/include/mios/memory/memory.hpp
@@ -6,6 +6,7 @@
 #include "mios/data_structures/parameters.hpp"
 #include "mios/data_structures/task_data.hpp"
 #include "mios/data_structures/percept.hpp"
+#include "mios/utils/configuration.hpp"
 
 #include "nlohmann/json.hpp"
 
@@ -20,12 +21,12 @@ class Core;
 
 class Memory{
 public:
-    Memory(unsigned database_port, std::string robot_arm);
+    Memory(const MiosConfiguration &configuration);
     Memory(const Memory&) = delete;
     void operator=(Memory const&) = delete;
     bool is_ok() const;
 
-    bool initialize(SkillLibrary* skill_library, unsigned robot_configuration);
+    bool initialize(SkillLibrary* skill_library);
     bool load_default_parameters(nlohmann::json& parameters);
     bool set_default_parameters();
     bool apply_skill_context(const nlohmann::json& context, const std::string skill_id);
@@ -64,7 +65,7 @@ public:
     bool get_task_data(const std::string uuid,TaskData& data) const;
     Object *get_object(const std::string& name);
     const Event* get_event(const std::string& name);
-    std::string m_robot_arm;
+    MiosConfiguration m_configuration;
 
     LTMemory m_lt_memory;
 private:

--- a/src/memory/include/mios/memory/memory.hpp
+++ b/src/memory/include/mios/memory/memory.hpp
@@ -6,7 +6,7 @@
 #include "mios/data_structures/parameters.hpp"
 #include "mios/data_structures/task_data.hpp"
 #include "mios/data_structures/percept.hpp"
-#include "mios/utils/configuration.hpp"
+#include "mios/utils/context.hpp"
 
 #include "nlohmann/json.hpp"
 
@@ -21,7 +21,7 @@ class Core;
 
 class Memory{
 public:
-    Memory(const MiosConfiguration &configuration);
+    Memory(const MiosContext &context);
     Memory(const Memory&) = delete;
     void operator=(Memory const&) = delete;
     bool is_ok() const;
@@ -65,7 +65,7 @@ public:
     bool get_task_data(const std::string uuid,TaskData& data) const;
     Object *get_object(const std::string& name);
     const Event* get_event(const std::string& name);
-    MiosConfiguration m_configuration;
+    MiosContext m_context;
 
     LTMemory m_lt_memory;
 private:

--- a/src/memory/src/lt_memory.cpp
+++ b/src/memory/src/lt_memory.cpp
@@ -8,9 +8,11 @@
 
 namespace mios {
 
-LTMemory::LTMemory(unsigned database_port, std::string robot_arm):m_mongodb_client((robot_arm == "left") ? "miosL" : "miosR", database_port){
-    spdlog::trace("LTMemory::LTMemory");
-    m_database_port= database_port;
+LTMemory::LTMemory(const MiosConfiguration &configuration):
+    m_mongodb_client(configuration.database_name, configuration.database_port),
+    m_configuration(configuration){
+        spdlog::trace("LTMemory::LTMemory");
+
 }
 
 bool LTMemory::is_ok() const{
@@ -32,39 +34,39 @@ void LTMemory::link_to_skill_library(SkillLibrary *skill_library){
     m_skill_library=skill_library;
 }
 
-bool LTMemory::initialize(unsigned robot_configuration){
+bool LTMemory::initialize(){
     spdlog::trace("LTMemory::initialize");
     if(!make_database_consistent()){
         return false;
     }
 
-    nlohmann::json system_parameters;
-    m_mongodb_client.read_document("system","parameters",system_parameters);
-    switch(robot_configuration){
-    case 0:
-        system_parameters["has_robot"]=true;
-        system_parameters["gripper"]="Default";
-        m_mongodb_client.write_document("system","parameters",system_parameters,true);
-        break;
-    case 1:
-        system_parameters["has_robot"]=true;
-        system_parameters["gripper"]="None";
-        m_mongodb_client.write_document("system","parameters",system_parameters,true);
-        break;
-    case 2:
-        system_parameters["has_robot"]=true;
-        system_parameters["gripper"]="Softhand2";
-        m_mongodb_client.write_document("system","parameters",system_parameters,true);
-        break;
-    case 3:
-        system_parameters["has_robot"]=false;
-        system_parameters["gripper"]="None";
-        m_mongodb_client.write_document("system","parameters",system_parameters,true);
-        break;
-    default:
-        spdlog::error("Robot configuration " + std::to_string(robot_configuration) + " does not exist.");
-        return false;
-    }
+    // nlohmann::json system_parameters;
+    // m_mongodb_client.read_document("system","parameters",system_parameters);
+    // switch(m_configuration.robot_configuration){
+    // case 0:
+    //     system_parameters["has_robot"]=true;
+    //     system_parameters["gripper"]="Default";
+    //     m_mongodb_client.write_document("system","parameters",system_parameters,true);
+    //     break;
+    // case 1:
+    //     system_parameters["has_robot"]=true;
+    //     system_parameters["gripper"]="None";
+    //     m_mongodb_client.write_document("system","parameters",system_parameters,true);
+    //     break;
+    // case 2:
+    //     system_parameters["has_robot"]=true;
+    //     system_parameters["gripper"]="Softhand2";
+    //     m_mongodb_client.write_document("system","parameters",system_parameters,true);
+    //     break;
+    // case 3:
+    //     system_parameters["has_robot"]=false;
+    //     system_parameters["gripper"]="None";
+    //     m_mongodb_client.write_document("system","parameters",system_parameters,true);
+    //     break;
+    // default:
+    //     spdlog::error("Robot configuration " + std::to_string(m_configuration.robot_configuration) + " does not exist.");
+    //     return false;
+    // }
 
     return true;
 }
@@ -72,11 +74,11 @@ bool LTMemory::initialize(unsigned robot_configuration){
 bool LTMemory::make_database_consistent(){
     spdlog::trace("LTMemory::make_database_consistent");
     nlohmann::json default_values;
-    default_values=SystemParameters().to_json();
-    default_values["name"]="system";
-    if(!m_mongodb_client.make_document_consistent("system","parameters",default_values)){
-        return false;
-    }
+    // default_values=SystemParameters().to_json();
+    // default_values["name"]="system";
+    // if(!m_mongodb_client.make_document_consistent("system","parameters",default_values)){
+    //     return false;
+    // }
     default_values=SafetyParameters().to_json();
     default_values["name"]="safety";
     if(!m_mongodb_client.make_document_consistent("safety","parameters",default_values)){
@@ -318,9 +320,9 @@ bool LTMemory::load_default_parameters(nlohmann::json &parameters){
     if(!m_mongodb_client.read_document("safety","parameters",parameters["safety"])){
         return false;
     }
-    if(!m_mongodb_client.read_document("system","parameters",parameters["system"])){
-        return false;
-    }
+    // if(!m_mongodb_client.read_document("system","parameters",parameters["system"])){
+    //     return false;
+    // }
     if(!m_mongodb_client.read_document("user","parameters",parameters["user"])){
         return false;
     }
@@ -390,9 +392,9 @@ bool LTMemory::upload_log_element(const nlohmann::json& log_entry){
 
 bool LTMemory::update_database(){
     spdlog::trace("LTMemory::update_database");
-    if(!m_mongodb_client.write_document("system","parameters",m_st_memory->read_parameters()->system.to_json(),true)){
-        return false;
-    }
+    // if(!m_mongodb_client.write_document("system","parameters",m_st_memory->read_parameters()->system.to_json(),true)){
+    //     return false;
+    // }
     //    if(!m_mongodb_client.write_document("user","parameters",m_st_memory->read_parameters()->user.to_json(),true)){
     //        return false;
     //    }

--- a/src/memory/src/lt_memory.cpp
+++ b/src/memory/src/lt_memory.cpp
@@ -8,9 +8,9 @@
 
 namespace mios {
 
-LTMemory::LTMemory(const MiosConfiguration &configuration):
-    m_mongodb_client(configuration.database_name, configuration.database_port),
-    m_configuration(configuration){
+LTMemory::LTMemory(const MiosContext &context):
+    m_mongodb_client(context.config.database_name, context.config.database_port),
+    m_context(context){
         spdlog::trace("LTMemory::LTMemory");
 
 }
@@ -42,7 +42,7 @@ bool LTMemory::initialize(){
 
     // nlohmann::json system_parameters;
     // m_mongodb_client.read_document("system","parameters",system_parameters);
-    // switch(m_configuration.robot_configuration){
+    // switch(m_context.config.robot_configuration){
     // case 0:
     //     system_parameters["has_robot"]=true;
     //     system_parameters["gripper"]="Default";
@@ -64,7 +64,7 @@ bool LTMemory::initialize(){
     //     m_mongodb_client.write_document("system","parameters",system_parameters,true);
     //     break;
     // default:
-    //     spdlog::error("Robot configuration " + std::to_string(m_configuration.robot_configuration) + " does not exist.");
+    //     spdlog::error("Robot configuration " + std::to_string(m_context.config.robot_configuration) + " does not exist.");
     //     return false;
     // }
 

--- a/src/memory/src/memory.cpp
+++ b/src/memory/src/memory.cpp
@@ -3,11 +3,10 @@
 
 namespace mios {
 
-Memory::Memory(unsigned database_port, std::string robot_arm):m_lt_memory(database_port, robot_arm){
+Memory::Memory(const MiosConfiguration &configuration):m_lt_memory(configuration),m_configuration(configuration){
     spdlog::trace("Memory::Memory");
     m_st_memory.link_to_lt_memory(&m_lt_memory);
     m_lt_memory.link_to_st_memory(&m_st_memory);
-    m_robot_arm = robot_arm;
 }
 
 bool Memory::is_ok() const{
@@ -23,11 +22,11 @@ bool Memory::is_ok() const{
     return true;
 }
 
-bool Memory::initialize(SkillLibrary *skill_library, unsigned robot_configuration){
+bool Memory::initialize(SkillLibrary *skill_library){
     spdlog::trace("Memory::initialize");
     spdlog::info("Initializing long-term memory...");
     m_lt_memory.link_to_skill_library(skill_library);
-    if(!m_lt_memory.initialize(robot_configuration)){
+    if(!m_lt_memory.initialize()){
         spdlog::error("Could not initialize long-term memory.");
         return false;
     }

--- a/src/memory/src/memory.cpp
+++ b/src/memory/src/memory.cpp
@@ -3,7 +3,7 @@
 
 namespace mios {
 
-Memory::Memory(const MiosConfiguration &configuration):m_lt_memory(configuration),m_configuration(configuration){
+Memory::Memory(const MiosContext &context):m_lt_memory(context),m_context(context){
     spdlog::trace("Memory::Memory");
     m_st_memory.link_to_lt_memory(&m_lt_memory);
     m_lt_memory.link_to_st_memory(&m_st_memory);

--- a/src/memory/src/st_memory.cpp
+++ b/src/memory/src/st_memory.cpp
@@ -144,10 +144,10 @@ bool STMemory::apply_skill_context(const nlohmann::json task_context, const std:
         spdlog::error("Could not apply safety parameters from context for skill " + skill_id);
         return false;
     }
-    if(!m_parameters.system.from_json(task_context["skills"][skill_id]["system"])){
-        spdlog::error("Could not apply system parameters from context for skill " + skill_id);
-        return false;
-    }
+    // if(!m_parameters.system.from_json(task_context["skills"][skill_id]["system"])){
+    //     spdlog::error("Could not apply system parameters from context for skill " + skill_id);
+    //     return false;
+    // }
     if(!m_parameters.user.from_json(task_context["skills"][skill_id]["user"])){
         spdlog::error("Could not apply user parameters from context for skill " + skill_id);
         return false;
@@ -199,10 +199,10 @@ bool STMemory::reserve_parameters(const nlohmann::json task_context, const std::
         spdlog::error("Could not apply safety parameters from context for skill " + skill_id);
         return false;
     }
-    if(!m_reserved_parameters[skill_id].system.from_json(task_context["skills"][skill_id]["system"])){
-        spdlog::error("Could not apply system parameters from context for skill " + skill_id);
-        return false;
-    }
+    // if(!m_reserved_parameters[skill_id].system.from_json(task_context["skills"][skill_id]["system"])){
+    //     spdlog::error("Could not apply system parameters from context for skill " + skill_id);
+    //     return false;
+    // }
     if(!m_reserved_parameters[skill_id].user.from_json(task_context["skills"][skill_id]["user"])){
         spdlog::error("Could not apply user parameters from context for skill " + skill_id);
         return false;
@@ -235,9 +235,9 @@ bool STMemory::set_default_parameters(){
     if(!m_parameters.limits.from_json(default_parameters["limits"])){
         return false;
     }
-    if(!m_parameters.system.from_json(default_parameters["system"])){
-        return false;
-    }
+    // if(!m_parameters.system.from_json(default_parameters["system"])){
+    //     return false;
+    // }
     if(!m_parameters.safety.from_json(default_parameters["safety"])){
         return false;
     }

--- a/src/panda/include/mios/panda/panda_body.hpp
+++ b/src/panda/include/mios/panda/panda_body.hpp
@@ -10,6 +10,7 @@
 
 #include "mios/data_structures/parameters.hpp"
 #include "mios/utils/types.hpp"
+#include "mios/utils/configuration.hpp"
 
 #include <string>
 #include <optional>
@@ -28,7 +29,7 @@ class Memory;
 class PandaBody{
 public:
     PandaBody(Memory* memory);
-    bool initialize();
+    bool initialize(const MiosConfiguration &configuration);
     bool connect_to_robot(const std::optional<std::string> &ip);
     bool connect_to_gripper(const std::optional<std::string> &ip);
     void disconnect_from_robot();
@@ -116,6 +117,7 @@ private:
 
 private:
     Memory* m_memory;
+    MiosConfiguration m_configuration;
 };
 
 }

--- a/src/panda/include/mios/panda/panda_body.hpp
+++ b/src/panda/include/mios/panda/panda_body.hpp
@@ -10,7 +10,7 @@
 
 #include "mios/data_structures/parameters.hpp"
 #include "mios/utils/types.hpp"
-#include "mios/utils/configuration.hpp"
+#include "mios/utils/context.hpp"
 
 #include <string>
 #include <optional>
@@ -28,8 +28,8 @@ class Memory;
 
 class PandaBody{
 public:
-    PandaBody(Memory* memory);
-    bool initialize(const MiosConfiguration &configuration);
+    PandaBody(Memory* memory, const MiosContext &conftext);
+    bool initialize();
     bool connect_to_robot(const std::optional<std::string> &ip);
     bool connect_to_gripper(const std::optional<std::string> &ip);
     void disconnect_from_robot();
@@ -117,7 +117,7 @@ private:
 
 private:
     Memory* m_memory;
-    MiosConfiguration m_configuration;
+    MiosContext m_context;
 };
 
 }

--- a/src/panda/src/panda_body.cpp
+++ b/src/panda/src/panda_body.cpp
@@ -16,29 +16,64 @@
 
 namespace mios {
 
-PandaBody::PandaBody(Memory *memory):m_panda_arm(nullptr),m_panda_model(nullptr),m_panda_hand(nullptr),m_has_arm(false),m_hand(PandaHandNone),m_arm_connected(false),m_hand_connected(false),
-m_memory(memory){
-    spdlog::trace("PandaBody::PandaBody");
-    m_robot_state.O_T_EE={1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1};
+PandaBody::PandaBody(Memory *memory):
+    m_panda_arm(nullptr),
+    m_panda_model(nullptr),
+    m_panda_hand(nullptr),
+    m_has_arm(false),
+    m_hand(PandaHandNone),
+    m_arm_connected(false),
+    m_hand_connected(false),
+    m_memory(memory){
+        spdlog::trace("PandaBody::PandaBody");
+        m_robot_state.O_T_EE={1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1};
 }
 
-bool PandaBody::initialize(){
+bool PandaBody::initialize(const MiosConfiguration &configuration){
     spdlog::trace("PandaBody::initialize()");
-    m_has_arm=m_memory->read_parameters()->system.has_robot;
-    //m_hand=m_memory->read_parameters()->system.gripper; // get hand automatically form desk
-    
+    m_configuration = configuration;
+
+    switch(m_configuration.robot_configuration){
+        case 0:     
+            m_has_arm=true;
+            m_hand=PandaHand::PandaHandDefault;    // will be overwritten by ensure_robot_ready (deskapi)  
+            break;
+        case 1:     
+            m_has_arm=true;
+            m_hand=PandaHand::PandaHandNone;      // will be overwritten by ensure_robot_ready (deskapi)  
+            break;
+        case 2:     
+            m_has_arm=true;
+            m_hand=PandaHand::PandaHandSofthand2;      
+            break;
+        case 3:    
+            m_has_arm=false;
+            m_hand=PandaHand::PandaHandNone;     
+            break;
+        case 4:     
+            m_has_arm=true;
+            m_hand=PandaHand::PandaHandDefault;    
+            break;
+        case 5:     
+            m_has_arm=true;
+            m_hand=PandaHand::PandaHandNone;    
+            break;
+        default:
+            spdlog::error("Robot configuration " + std::to_string(m_configuration.robot_configuration) + " does not exist.");
+            return false;
+    }
     std::optional<std::string> ip;
     if(m_has_arm){
     //request control and activate FCI
         spdlog::debug("PandaBody::initialize()");
-        ip = PandaBody::ping_robot(m_memory->get_parameters()->system.robot_ip);     
+        ip = PandaBody::ping_robot(m_configuration.robot_ip);     
     }
 
-    m_memory->get_parameters()->system.robot_ip = ip.value_or("127.0.0.1");
-    if(!connect_to_robot(m_memory->read_parameters()->system.robot_ip)){
+    // m_configuration.robot_ip = ip.value_or("127.0.0.1");
+    if(!connect_to_robot(m_configuration.robot_ip)){
         return false;
     }
-    if(!connect_to_gripper(m_memory->read_parameters()->system.robot_ip)){
+    if(!connect_to_gripper(m_configuration.robot_ip)){
         return false;
     }
     load_gripper_configuration();
@@ -231,7 +266,7 @@ bool PandaBody::pre_run_checks() const{
 bool PandaBody::is_robot(const std::string &ip){
     spdlog::debug("PandaBody::is_robot("+ip+")" );
     bool result = false;
-    while(!result){
+    while(!result && m_configuration.robot_configuration<2){
         result = ensure_robot_ready();
     }
     m_memory->set_default_parameters();
@@ -946,7 +981,7 @@ bool PandaBody::shutdown_robot(){
         disconnect_from_robot();
         std::this_thread::sleep_for(std::chrono::seconds(5));
         result=false;
-        while(!this->initialize()){
+        while(!this->initialize(m_configuration)){
             spdlog::warn("Robot initialization failed. Wait and retry...");
             std::this_thread::sleep_for(std::chrono::seconds(5));
         }   
@@ -956,8 +991,6 @@ bool PandaBody::shutdown_robot(){
 
 bool PandaBody::reboot_robot(){
     spdlog::trace("PandaBody::reboot_robot");
-    bool reconnect_arm = m_has_arm;
-    bool reconnect_hand = m_arm_connected;
 
     //deactivate_fci();
     bool result;
@@ -982,7 +1015,7 @@ bool PandaBody::reboot_robot(){
         disconnect_from_robot();
         std::this_thread::sleep_for(std::chrono::seconds(5));
         result=false;
-        while(!this->initialize()){
+        while(!this->initialize(m_configuration)){
             spdlog::warn("Robot initialization failed. Wait and retry...");
             std::this_thread::sleep_for(std::chrono::seconds(5));
         }

--- a/src/panda/src/panda_body.cpp
+++ b/src/panda/src/panda_body.cpp
@@ -16,7 +16,7 @@
 
 namespace mios {
 
-PandaBody::PandaBody(Memory *memory):
+PandaBody::PandaBody(Memory *memory,const MiosContext &context):
     m_panda_arm(nullptr),
     m_panda_model(nullptr),
     m_panda_hand(nullptr),
@@ -24,16 +24,16 @@ PandaBody::PandaBody(Memory *memory):
     m_hand(PandaHandNone),
     m_arm_connected(false),
     m_hand_connected(false),
+    m_context(context),
     m_memory(memory){
         spdlog::trace("PandaBody::PandaBody");
         m_robot_state.O_T_EE={1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1};
 }
 
-bool PandaBody::initialize(const MiosConfiguration &configuration){
+bool PandaBody::initialize(){
     spdlog::trace("PandaBody::initialize()");
-    m_configuration = configuration;
 
-    switch(m_configuration.robot_configuration){
+    switch(m_context.config.robot_configuration){
         case 0:     
             m_has_arm=true;
             m_hand=PandaHand::PandaHandDefault;    // will be overwritten by ensure_robot_ready (deskapi)  
@@ -50,30 +50,22 @@ bool PandaBody::initialize(const MiosConfiguration &configuration){
             m_has_arm=false;
             m_hand=PandaHand::PandaHandNone;     
             break;
-        case 4:     
-            m_has_arm=true;
-            m_hand=PandaHand::PandaHandDefault;    
-            break;
-        case 5:     
-            m_has_arm=true;
-            m_hand=PandaHand::PandaHandNone;    
-            break;
         default:
-            spdlog::error("Robot configuration " + std::to_string(m_configuration.robot_configuration) + " does not exist.");
+            spdlog::error("Robot configuration " + std::to_string(m_context.config.robot_configuration) + " does not exist.");
             return false;
     }
     std::optional<std::string> ip;
     if(m_has_arm){
     //request control and activate FCI
         spdlog::debug("PandaBody::initialize()");
-        ip = PandaBody::ping_robot(m_configuration.robot_ip);     
+        ip = PandaBody::ping_robot(m_context.config.robot_ip);     
     }
 
-    // m_configuration.robot_ip = ip.value_or("127.0.0.1");
-    if(!connect_to_robot(m_configuration.robot_ip)){
+    // m_context.config.robot_ip = ip.value_or("127.0.0.1");
+    if(!connect_to_robot(m_context.config.robot_ip)){
         return false;
     }
-    if(!connect_to_gripper(m_configuration.robot_ip)){
+    if(!connect_to_gripper(m_context.config.robot_ip)){
         return false;
     }
     load_gripper_configuration();
@@ -96,11 +88,15 @@ bool PandaBody::initialize(const MiosConfiguration &configuration){
 std::optional<std::string> PandaBody::ping_robot(const std::optional<std::string> &last_ip){
     spdlog::trace("PandaBody::ping_robot("+last_ip.value()+")");
     std::optional<std::string> new_ip={};
+    unsigned count=0;
     spdlog::debug("PandaBody: ping_robot("+last_ip.value_or("127.0.0.1")+")");
     //check given IP:
     while(!new_ip.has_value()){
         if(last_ip.has_value()){
-            if(mirmi_utils::ping(last_ip.value().c_str())==false){
+            if(m_context.shutdown_signal){
+                break;
+            }
+            if(mirmi_utils::ping(last_ip.value().c_str())==false && count%10000==0){
                 spdlog::warn("IP was set to "+last_ip.value()+" but no device has been found. Searching for new connection...");
             }else{
                 if(is_robot(last_ip.value_or("127.0.0.1"))){ // 
@@ -109,30 +105,31 @@ std::optional<std::string> PandaBody::ping_robot(const std::optional<std::string
                 }
             }
         }
+        count++;
     }
-    // search for robot IP:
-    if(!new_ip.has_value()){
-        std::map<std::string,std::string> ifaces = mirmi_utils::get_subnets();
-        std::string address;
-        for(const auto& i : ifaces){
-            if(i.first=="lo" || i.first=="docker0" || i.first=="tap0" || i.first=="flannel.1" || i.first.substr(0,3)=="enx" || i.first.substr(0,3)=="wlp" || i.first.substr(0,2)=="br" || i.first.substr(0,4)=="enp4"){
-                continue;
-            }
-            for(unsigned j=2;j<255;j++){
-                address=i.second +std::to_string(j);
-                if(!mirmi_utils::ping(address.c_str())){
-                    spdlog::debug("Cannot find device at "+address+" on interface "+i.first+".");
-                    continue;
-                }else{
-                    spdlog::info("Found device at ip "+address+" at interface "+i.first+".");
-                    if(is_robot(address)){  // 
-                        new_ip = address;
-                        return new_ip;
-                    }
-                }
-            }
-        }
-    }
+    // // search for robot IP:
+    // if(!new_ip.has_value()){
+    //     std::map<std::string,std::string> ifaces = mirmi_utils::get_subnets();
+    //     std::string address;
+    //     for(const auto& i : ifaces){
+    //         if(i.first=="lo" || i.first=="docker0" || i.first=="tap0" || i.first=="flannel.1" || i.first.substr(0,3)=="enx" || i.first.substr(0,3)=="wlp" || i.first.substr(0,2)=="br" || i.first.substr(0,4)=="enp4"){
+    //             continue;
+    //         }
+    //         for(unsigned j=2;j<255;j++){
+    //             address=i.second +std::to_string(j);
+    //             if(!mirmi_utils::ping(address.c_str())){
+    //                 spdlog::debug("Cannot find device at "+address+" on interface "+i.first+".");
+    //                 continue;
+    //             }else{
+    //                 spdlog::info("Found device at ip "+address+" at interface "+i.first+".");
+    //                 if(is_robot(address)){  // 
+    //                     new_ip = address;
+    //                     return new_ip;
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
     spdlog::warn("PandaBody::ping_robot: Cannot find Robot");
     return new_ip;
 
@@ -266,7 +263,7 @@ bool PandaBody::pre_run_checks() const{
 bool PandaBody::is_robot(const std::string &ip){
     spdlog::debug("PandaBody::is_robot("+ip+")" );
     bool result = false;
-    while(!result && m_configuration.robot_configuration<2){
+    while(!result && m_context.config.use_desk && !m_context.shutdown_signal){
         result = ensure_robot_ready();
     }
     m_memory->set_default_parameters();
@@ -912,6 +909,10 @@ void PandaBody::get_default_gripper_state(franka::GripperState &state) const{
 
 bool PandaBody::activate_fci(){
     spdlog::trace("PandaBody::activate_fci()");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");
@@ -935,6 +936,10 @@ bool PandaBody::activate_fci(){
 
 bool PandaBody::deactivate_fci(){
     spdlog::trace("PandaBody::deactivate_fci()");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");
@@ -959,6 +964,10 @@ bool PandaBody::deactivate_fci(){
 
 bool PandaBody::shutdown_robot(){
     spdlog::trace("PandaBody::shutdown_robot");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");
@@ -981,7 +990,7 @@ bool PandaBody::shutdown_robot(){
         disconnect_from_robot();
         std::this_thread::sleep_for(std::chrono::seconds(5));
         result=false;
-        while(!this->initialize(m_configuration)){
+        while(!this->initialize()){
             spdlog::warn("Robot initialization failed. Wait and retry...");
             std::this_thread::sleep_for(std::chrono::seconds(5));
         }   
@@ -991,7 +1000,10 @@ bool PandaBody::shutdown_robot(){
 
 bool PandaBody::reboot_robot(){
     spdlog::trace("PandaBody::reboot_robot");
-
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     //deactivate_fci();
     bool result;
     try{
@@ -1015,7 +1027,7 @@ bool PandaBody::reboot_robot(){
         disconnect_from_robot();
         std::this_thread::sleep_for(std::chrono::seconds(5));
         result=false;
-        while(!this->initialize(m_configuration)){
+        while(!this->initialize()){
             spdlog::warn("Robot initialization failed. Wait and retry...");
             std::this_thread::sleep_for(std::chrono::seconds(5));
         }
@@ -1026,6 +1038,10 @@ bool PandaBody::reboot_robot(){
 
 bool PandaBody::unlock_brakes(){  // make sure it is waiting until all brakes are unlocked
     spdlog::trace("PandaBody::unlock_brakes");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");
@@ -1049,6 +1065,10 @@ bool PandaBody::unlock_brakes(){  // make sure it is waiting until all brakes ar
 
 bool PandaBody::lock_brakes(){  // make sure it is waiting until all brakes are locked
     spdlog::trace("PandaBody::lock_brakes");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");
@@ -1072,6 +1092,10 @@ bool PandaBody::lock_brakes(){  // make sure it is waiting until all brakes are 
 
 bool PandaBody::ensure_robot_ready(){  // put this in interface
     spdlog::trace("PandaBody::ensure_robot_ready");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("keep_alive");
@@ -1105,6 +1129,10 @@ bool PandaBody::ensure_robot_ready(){  // put this in interface
 
 bool PandaBody::programming(){  // put this in interface
     spdlog::trace("PandaBody::programming");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");
@@ -1128,6 +1156,10 @@ bool PandaBody::programming(){  // put this in interface
 
 bool PandaBody::execution(){  // put this in interface
     spdlog::trace("PandaBody::execution");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");
@@ -1151,6 +1183,10 @@ bool PandaBody::execution(){  // put this in interface
 
 bool PandaBody::release_control(){
     spdlog::trace("PandaBody::release_control");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");
@@ -1173,6 +1209,10 @@ bool PandaBody::release_control(){
 }
 bool PandaBody::take_control(){
     spdlog::trace("PandaBody::take_control");
+    if(!m_context.config.use_desk){
+        spdlog::error("DESK features are not activated.");
+        return false;
+    }
     bool result;
     try{
         pybind11::module deskapi = pybind11::module::import("deskapi");

--- a/src/panda/src/panda_body.cpp
+++ b/src/panda/src/panda_body.cpp
@@ -96,8 +96,10 @@ std::optional<std::string> PandaBody::ping_robot(const std::optional<std::string
             if(m_context.shutdown_signal){
                 break;
             }
-            if(mirmi_utils::ping(last_ip.value().c_str())==false && count%10000==0){
-                spdlog::warn("IP was set to "+last_ip.value()+" but no device has been found. Searching for new connection...");
+            if(mirmi_utils::ping(last_ip.value().c_str())==false ){
+                if(count%10000==0){
+                    spdlog::warn("IP was set to "+last_ip.value()+" but no device has been found. Searching for new connection...");
+                }  
             }else{
                 if(is_robot(last_ip.value_or("127.0.0.1"))){ // 
                     new_ip=last_ip;

--- a/src/task/src/task.cpp
+++ b/src/task/src/task.cpp
@@ -418,7 +418,7 @@ std::string Task::get_uuid() const{
 bool Task::check_context(const nlohmann::json &default_context, const nlohmann::json &user_context) const{
 
     std::unordered_set<std::string> top_level={"name","parameters","skills","_id","subtasks"};
-    std::unordered_set<std::string> skill_level={"skill","control","limits","system","safety","frames","user","type"};
+    std::unordered_set<std::string> skill_level={"skill","control","limits","safety","frames","user","type"};  //,"system"
 
     try{
         for(const auto& el : default_context.items()){

--- a/src/task/src/task.cpp
+++ b/src/task/src/task.cpp
@@ -391,6 +391,9 @@ TaskResult Task::get_subtask_result(const std::string &subtask_name) const{
 
 void Task::sleep_1ms() const{
     while(!m_flag_stop){
+        if(m_core->m_context.shutdown_signal){
+            break;
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 }

--- a/src/task/src/task_engine.cpp
+++ b/src/task/src/task_engine.cpp
@@ -36,6 +36,9 @@ void TaskEngine::life_cycle(){
     bool reflex=false;
     bool recovery=false;
     while(m_keep_running){
+        if(m_core->m_context.shutdown_signal){
+            m_core->terminate();
+        }
         if(m_task_life_cycle==TaskLifeCycle::PreChecks){
             if(!m_core->is_ready()){
                 spdlog::warn("Core is not ready, I will attempt to reinitialize...");

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,6 +19,8 @@ set(${MODULE_NAME}_HEADER_FILES
     include/${PROJECT_NAME}/data_structures/results.hpp
     include/${PROJECT_NAME}/data_structures/task_data.hpp
     include/${PROJECT_NAME}/utils/exceptions.hpp
+    include/${PROJECT_NAME}/utils/types.hpp
+    include/${PROJECT_NAME}/utils/configuration.hpp
     )
 
 add_library(${MODULE_NAME}

--- a/src/utils/include/mios/data_structures/parameters.hpp
+++ b/src/utils/include/mios/data_structures/parameters.hpp
@@ -120,12 +120,12 @@ public:
     bool from_json(const nlohmann::json& parameters);
     nlohmann::json to_json() const;
 
-    std::string robot_ip;
+    // std::string robot_ip;
     //std::string desk_user;
     //std::string desk_pwd;
 
-    bool has_robot;
-    PandaHand gripper;
+    // bool has_robot;
+    // PandaHand gripper;
 
     std::string spoc_token;
     //bool spoc_in_control;

--- a/src/utils/include/mios/utils/configuration.hpp
+++ b/src/utils/include/mios/utils/configuration.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <string>
+
+namespace mios{
+
+struct MiosConfiguration {
+    std::string verbosity;
+    std::string robot_ip;
+    std::string database_name;
+
+    unsigned    robot_configuration;
+    unsigned    database_port;
+    unsigned    websocket_port;
+    unsigned    udp_port;
+    unsigned    rpc_port;
+};
+
+}

--- a/src/utils/include/mios/utils/configuration.hpp
+++ b/src/utils/include/mios/utils/configuration.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <iostream>
 
 namespace mios{
 
@@ -13,6 +14,21 @@ struct MiosConfiguration {
     unsigned    websocket_port;
     unsigned    udp_port;
     unsigned    rpc_port;
+    bool        use_desk;
+    // Define how this struct should be printed
+    friend std::ostream& operator<<(std::ostream& os, const MiosConfiguration& c) {
+        os << "MiosConfiguration: {\n"
+           << "  verbosity:           " << c.verbosity << "\n"
+           << "  robot_ip:            " << c.robot_ip << "\n"
+           << "  robot_configuration: " << c.robot_configuration << "\n"
+           << "  use_desk:            " << c.use_desk << "\n"
+           << "  database_name:       " << c.database_name << "\n"
+           << "  database_port:       " << c.database_port << "\n"
+           << "  websocket_port:      " << c.websocket_port << "\n"
+           << "  rpc_port:            " << c.rpc_port << "\n"
+           << "  udp_port:            " << c.udp_port << "\n";
+        return os;
+    }
 };
 
 }

--- a/src/utils/include/mios/utils/context.hpp
+++ b/src/utils/include/mios/utils/context.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <atomic>
+#include "mios/utils/configuration.hpp"
+
+struct MiosContext {
+    // static MIOS configuration
+    const mios::MiosConfiguration& config;
+    
+    // Represents status of SIG Signals:
+    std::atomic<bool>& shutdown_signal;
+    
+    // Future proofing:
+    // e.g., ServiceLocator& services;
+    // e.g., spdlog::logger& logger;
+};

--- a/src/utils/src/parameters.cpp
+++ b/src/utils/src/parameters.cpp
@@ -370,22 +370,23 @@ nlohmann::json FramesParameters::to_json() const{
 }
 
 SystemParameters::SystemParameters(){
-    robot_ip="127.0.0.1";
-    //desk_user="";
-    //desk_pwd="";
+    // robot_ip="127.0.0.1";
+    // //desk_user="";
+    // //desk_pwd="";
 
-    has_robot=false;
-    gripper=PandaHandNone;
+    // has_robot=false;
+    // gripper=PandaHandNone;
 
     spoc_token = "";
     //spoc_in_control = false;
 }
 
 bool SystemParameters::from_json(const nlohmann::json &parameters){
-    if(!mirmi_utils::read_json_param(parameters,"robot_ip",robot_ip)){
-        spdlog::error("Could not read robot_ip.");
-        return false;
-    }/*
+    // if(!mirmi_utils::read_json_param(parameters,"robot_ip",robot_ip)){
+    //     spdlog::error("Could not read robot_ip.");
+    //     return false;
+    // }
+    /*
     if(!mirmi_utils::read_json_param(parameters,"desk_name",desk_user)){
         spdlog::error("Could not read desk_name.");
         return false;
@@ -394,10 +395,10 @@ bool SystemParameters::from_json(const nlohmann::json &parameters){
         spdlog::error("Could not read desk_pwd.");
         return false;
     }*/
-    if(!mirmi_utils::read_json_param(parameters,"has_robot",has_robot)){
-        spdlog::error("Could not read has_robot.");
-        return false;
-    }
+    // if(!mirmi_utils::read_json_param(parameters,"has_robot",has_robot)){
+    //     spdlog::error("Could not read has_robot.");
+    //     return false;
+    // }
     if(!mirmi_utils::read_json_param(parameters,"spoc_token",spoc_token)){
         spdlog::error("Could not read spoc_token.");
         return false;
@@ -406,40 +407,40 @@ bool SystemParameters::from_json(const nlohmann::json &parameters){
         spdlog::error("Could not read spoc_in_control.");
         return false;
     }*/
-    std::string gripper_tmp;
-    if(!mirmi_utils::read_json_param(parameters,"gripper",gripper_tmp)){
-        spdlog::error("Could not read gripper.");
-        return false;
-    }
-    if(gripper_tmp=="Default"){
-        gripper=PandaHandDefault;
-    }else if(gripper_tmp=="Softhand2"){
-        gripper=PandaHandSofthand2;
-    }else{
-        gripper=PandaHandNone;
-    }
+    // std::string gripper_tmp;
+    // if(!mirmi_utils::read_json_param(parameters,"gripper",gripper_tmp)){
+    //     spdlog::error("Could not read gripper.");
+    //     return false;
+    // }
+    // if(gripper_tmp=="Default"){
+    //     gripper=PandaHandDefault;
+    // }else if(gripper_tmp=="Softhand2"){
+    //     gripper=PandaHandSofthand2;
+    // }else{
+    //     gripper=PandaHandNone;
+    // }
     return true;
 }
 
 nlohmann::json SystemParameters::to_json() const{
     nlohmann::json json_object;
-    json_object["robot_ip"]=robot_ip;
-    //json_object["desk_name"]=desk_user;
+    // json_object["robot_ip"]=robot_ip;
+    // //json_object["desk_name"]=desk_user;
     //json_object["desk_pwd"]=desk_pwd;
-    json_object["has_robot"]=has_robot;
+    // json_object["has_robot"]=has_robot;
     json_object["spoc_token"]=spoc_token;
     //json_object["spoc_in_control"]=spoc_in_control;
-    std::string gripper_tmp;
-    if(gripper==PandaHandNone){
-        gripper_tmp="None";
-    }
-    if(gripper==PandaHandDefault){
-        gripper_tmp="Default";
-    }
-    if(gripper==PandaHandSofthand2){
-        gripper_tmp="Softhand2";
-    }
-    json_object["gripper"]=gripper_tmp;
+    // std::string gripper_tmp;
+    // if(gripper==PandaHandNone){
+    //     gripper_tmp="None";
+    // }
+    // if(gripper==PandaHandDefault){
+    //     gripper_tmp="Default";
+    // }
+    // if(gripper==PandaHandSofthand2){
+    //     gripper_tmp="Softhand2";
+    // }
+    // json_object["gripper"]=gripper_tmp;
     return json_object;
 }
 

--- a/utils/mios.sh
+++ b/utils/mios.sh
@@ -6,5 +6,16 @@ export PYTHONPATH
 #export ROS_MASTER_URI=http://localhost:11311
 unset LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${ROOT}/../lib:${ROOT}/../lib/boost:${ROOT}/../lib/plugins:${ROOT}/../../dependencies:/opt/openrobots/lib      #ROS ${ROOT}/../lib/boost:/opt/ros/noetic/lib:
-exec ${ROOT}/mios $@
+exec ${ROOT}/mios \
+    ${verbosity:+--verbosity=$verbosity} \
+    ${database_port:+--database_port=$database_port} \
+    ${database_name:+--database_name=$database_name} \
+    ${robot_ip:+--robot_ip=$robot_ip} \
+    ${websocket_port:+--websocket_port=$websocket_port} \
+    ${rpc_port:+--rpc_port=$rpc_port} \
+    ${udp_port:+--udp_port=$udp_port} \
+    ${robot_config:+--robot_config=$robot_config} \
+    ${robot_arm:+--robot_arm=$robot_arm} \
+    ${desk:+--desk=$desk} \
+    "$@"
 exit 0


### PR DESCRIPTION
This PR introduces two major improvements to MIOS: graceful signal handling and a revised configuration system.

**Key Changes**
- Graceful Shutdown: Implemented handling for system signals. MIOS will now shut down cleanly when receiving SIGINT (Ctrl+C) or SIGTERM (docker stop).

- Configuration Overhaul: System parameters are now initialized at startup via command-line flags or environment variables. This removes the dependency on pre-existing MongoDB configurations.

**Supported Parameters**
Configuration can be set via flags (CLI) or environment variables (Docker). Available parameters include:

- verbosity (Default: debug)
- robot_ip (e.g., 192.168.3.100)
- ROBOT_USER (Used for DESK interface)
- ROBOT_PASSWORD (Used for DESK interface)
- database_name (Default: mios)
- database_port (Default: 27017)
- robot_config (Use 0 for arm+hand; use 1 for arm-only/libfranka-sim)
- desk (Default: true. Set to false for libfranka-sim)
- websocket_port (Default: 12000)
- rpc_port (Default: 12001)
- udp_port (Default: 12002)

**⚠️ Breaking Change / Action Required**
The previous configuration method via mongodb->parameters->system is deprecated.
- **Behavior**: If MIOS connects to a MongoDB instance that still contains legacy system configurations (e.g., robot_ip, desk_user), it will raise an error and shut down to prevent conflicts.
- **Action**: Please delete the mongodb->parameters->system collection (or the entire mongodb->parameters database) before running this version. MIOS will automatically repopulate the database with the correct parameter structure upon startup.

**Simulation Usage (libfranka-sim)**
To run MIOS with libfranka-sim, you can now use the --desk (or -d) flag to disable the DESK maintenance interface.
- Example: ./mios --desk false
- Ensure robot_config matches your simulation setup (e.g., use robot_config=1 for a simulation without a gripper).