### PR TITLE
Dev k8s connectivity

### DIFF
--- a/docker/compose/.env
+++ b/docker/compose/.env
@@ -1,8 +1,8 @@
 # .env file for docker-compose
 # This file defines the environment variables of mios, mios_mls and the mongo image
-ROBOT_IP=192.168.3.100
-ROBOT_CONFIG=0
-DESK=true
+ROBOT_IP=127.0.0.1
+ROBOT_CONFIG=1
+DESK=0
 DESK_USER=MBZUAI
 DESK_PW=mbzuai123
 MIOS_WS_PORT=12000

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mios:
-    image: "mirmi/mios:FR3"
+    image: "mirmi/mios:pingless"
     restart: always
     environment:
       - verbosity=${MIOS_VERBOSITY:-debug}
@@ -12,7 +12,7 @@ services:
       - database_name=${MOGNO_DB_NAME:-MBZUAI}
       - database_port=${MONGO_PORT:-27017}
       - robot_config=${ROBOT_CONFIG:-0}
-      - desk=${MIOS_DESK:-true}
+      - desk=${DESK:-true}
       - websocket_port=${MIOS_WS_PORT:-12000}
       - rpc_port=${MIOS_RPC_PORT:-12001}
       - udp_port=${MIOS_UPD_PORT:-12002}

--- a/src/panda/include/mios/panda/panda_body.hpp
+++ b/src/panda/include/mios/panda/panda_body.hpp
@@ -88,6 +88,7 @@ public:
 private:
     void load_gripper_configuration();
     std::optional<std::string> get_robot_ip(const std::optional<std::string>& last_ip);
+    bool is_service_reachable(const std::string& address, int port, int timeout_sec);
     bool is_robot(const std::string& ip);
     std::optional<std::string> find_robot();
     std::optional<std::string> find_device(const std::string &network_interface);

--- a/src/panda/src/panda_body.cpp
+++ b/src/panda/src/panda_body.cpp
@@ -96,7 +96,7 @@ std::optional<std::string> PandaBody::ping_robot(const std::optional<std::string
             if(m_context.shutdown_signal){
                 break;
             }
-            if(mirmi_utils::ping(last_ip.value().c_str())==false ){
+            if(is_service_reachable(last_ip.value().c_str(), 1337, 5)==false ){
                 if(count%10000==0){
                     spdlog::warn("IP was set to "+last_ip.value()+" but no device has been found. Searching for new connection...");
                 }  
@@ -135,6 +135,69 @@ std::optional<std::string> PandaBody::ping_robot(const std::optional<std::string
     spdlog::warn("PandaBody::ping_robot: Cannot find Robot");
     return new_ip;
 
+}
+
+bool PandaBody::is_service_reachable(const std::string& address, int port, int timeout_sec) {
+    struct addrinfo hints{}, *res, *ptr;
+    memset(&hints, 0, sizeof hints);
+    hints.ai_family = AF_UNSPEC;     // Allow IPv4 or IPv6
+    hints.ai_socktype = SOCK_STREAM; // TCP
+
+    // 1. Resolve Hostname
+    if (getaddrinfo(address.c_str(), std::to_string(port).c_str(), &hints, &res) != 0) {
+        return false;
+    }
+
+    bool is_connected = false;
+
+    // 2. Iterate through ALL resolved addresses (Crucial for K8s)
+    for (ptr = res; ptr != nullptr; ptr = ptr->ai_next) {
+        int sockfd = socket(ptr->ai_family, ptr->ai_socktype, ptr->ai_protocol);
+        if (sockfd < 0) continue;
+
+        // 3. Set Non-Blocking (FIXED SYNTAX)
+        int flags = fcntl(sockfd, F_GETFL, 0);
+        if (flags == -1 || fcntl(sockfd, F_SETFL, flags | O_NONBLOCK) == -1) {
+            close(sockfd);
+            continue;
+        }
+
+        // 4. Attempt Connection
+        int connect_result = connect(sockfd, ptr->ai_addr, ptr->ai_addrlen);
+
+        if (connect_result == 0) {
+            is_connected = true; // Connected immediately
+        } 
+        else if (errno == EINPROGRESS) {
+            // Connection in progress, wait using poll
+            struct pollfd pfd{};
+            pfd.fd = sockfd;
+            pfd.events = POLLOUT;
+
+            // poll expects milliseconds
+            int poll_res = poll(&pfd, 1, timeout_sec * 1000); 
+
+            if (poll_res > 0) {
+                // Poll succeeded, check socket error state
+                int so_error = 0;
+                socklen_t len = sizeof(so_error);
+                if (getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &so_error, &len) == 0) {
+                    if (so_error == 0) {
+                        is_connected = true;
+                    }
+                }
+            }
+        }
+
+        close(sockfd); // Always close the probe socket
+        
+        if (is_connected) {
+            break; // Stop trying other IPs if we found a working one
+        }
+    }
+
+    freeaddrinfo(res);
+    return is_connected;
 }
 
 void PandaBody::load_gripper_configuration(){

--- a/src/panda/src/panda_body.cpp
+++ b/src/panda/src/panda_body.cpp
@@ -189,7 +189,7 @@ bool PandaBody::is_service_reachable(const std::string& address, int port, int t
             }
         }
 
-        close(sockfd); // Always close the probe socket
+        close(sockfd); 
         
         if (is_connected) {
             break; // Stop trying other IPs if we found a working one


### PR DESCRIPTION
The changes will make mios k8s conform.
Instead of a ping mios will attempt a TCP connection to port 1337. 
If this is not successful mios will try again until the robot/simulation is online.
If this is successful mios can forward to create the connection via libfranka. 