### PR TITLE
update to libfranka 21.1

### DIFF
--- a/cmake/FetchContent.cmake
+++ b/cmake/FetchContent.cmake
@@ -22,7 +22,7 @@ FetchContent_Declare(
     #GIT_REPOSITORY https://github.com/frankarobotics/libfranka-release.git
     GIT_REPOSITORY https://github.com/frankarobotics/libfranka.git
     #GIT_TAG upstream/0.9.2)
-    GIT_TAG 0.17.0)
+    GIT_TAG 0.21.1)
     #GIT_REPOSITORY https://github.com/frankaemika/libfranka-release.git
     #GIT_TAG upstream/0.5.0)
     
@@ -30,10 +30,57 @@ FetchContent_Declare(
     #GIT_TAG 0.13.6)
 # list(APPEND CMAKE_PREFIX_PATH "/opt/openrobots/lib/cmake")  # libfranka >0.15
 
+
+# --- JSONRPC MANUAL CLONE HACK ---
+set(JSONRPC_DIR "${CMAKE_SOURCE_DIR}/_deps/jsonrpc-src")
+
+if(NOT EXISTS "${JSONRPC_DIR}/CMakeLists.txt")
+    message(STATUS "Hijacking FetchContent: Manually cloning jsonrpc v0.3.0...")
+    execute_process(
+        COMMAND git clone -b v0.3.0 https://github.com/jsonrpcx/json-rpc-cxx.git ${JSONRPC_DIR}
+        RESULT_VARIABLE clone_result
+    )
+    if(NOT clone_result EQUAL 0)
+        message(FATAL_ERROR "Manual Git clone failed for jsonrpc!")
+    endif()
+endif()
+
+FetchContent_Declare(
+    jsonrpc
+    SOURCE_DIR ${JSONRPC_DIR}
+)
+
+# 1. Define where we want the source to go
+set(MIRMI_UTILS_DIR "${CMAKE_SOURCE_DIR}/_deps/mirmi_cpp_utils-src")
+
+# 2. If it hasn't been cloned yet, do it manually using the command we know works
+if(NOT EXISTS "${MIRMI_UTILS_DIR}/CMakeLists.txt")
+    message(STATUS "Hijacking FetchContent: Manually cloning mirmi_utils dev_samu branch...")
+    execute_process(
+        COMMAND git clone -b v1.7.2 https://github.com/SchneiderROS/mirmi_utils ${MIRMI_UTILS_DIR}
+        RESULT_VARIABLE clone_result
+    )
+    if(NOT clone_result EQUAL 0)
+        message(FATAL_ERROR "Manual Git clone failed!")
+    endif()
+endif()
+
+# 3. Tell FetchContent to skip the download step and just use our manually cloned folder
 FetchContent_Declare(
     mirmi_cpp_utils
-    GIT_REPOSITORY https://github.com/SchneiderROS/mirmi_utils
-    GIT_TAG v1.7.2)
+    SOURCE_DIR ${MIRMI_UTILS_DIR}
+)
+
+
+
+# --- FIX FOR JSONRPC / DOCTEST GLIBC INCOMPATIBILITY ---
+# Force doctest to skip the problematic SIGSTKSZ array creation
+add_compile_definitions(DOCTEST_CONFIG_NO_POSIX_SIGNALS)
+
+# Aggressively tell dependencies not to build their tests or examples
+set(BUILD_TESTING OFF CACHE BOOL "Disable tests" FORCE)
+set(BUILD_TESTS OFF CACHE BOOL "Disable tests" FORCE)
+set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples" FORCE)
 
 set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE INTERNAL "")
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-boost/1.86.0
+boost/1.77.0
 eigen/3.4.0
 nlohmann_json/3.10.5
 simple-websocket-server/2.0.2

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mios:
-    image: "mirmi/mios:FR3"
+    image: "mirmi/mios:libfranka20"
     restart: always
     environment:
       - verbosity=${MIOS_VERBOSITY:-debug}
@@ -22,7 +22,7 @@ services:
     depends_on:
       - "mongo"
   mongo:
-    image: "mongo:7.0.14"
+    image: "mongo:7.0"
     ports:
       - "${MONGO_PORT:-27017}:${MONGO_PORT:-27017}"
     volumes:


### PR DESCRIPTION
 This changes update mios to use the new libfranka 21.1
 It also includes a workarounds for cmake/git fetchcontent bug that prevented proper integration of jsonrpc (needed in mirmi_utils). A second bug with jsonrpc (deprecated SIGSTKSZ signal) was also turned off. 