### PR TITLE
Add telemetry timestamp

### DIFF
--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -8,16 +8,24 @@ RUN apt-get update && \
     fping \
     curl \
     gnupg \
-    lsb-release
-RUN mkdir -p /etc/apt/keyrings && \
-    curl http://robotpkg.openrobots.org/packages/debian/robotpkg.asc | tee /etc/apt/keyrings/robotpkg.asc && \
-    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/robotpkg.asc] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" | tee /etc/apt/sources.list.d/robotpkg.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    robotpkg-pinocchio && \
-    # Clean up apt caches to keep the image small
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    wget \
+    lsb-release \
+    libpoco-dev \
+    libeigen3-dev \
+    libfmt-dev
+# No longer require pinnochio as a dependency
+# RUN mkdir -p /etc/apt/keyrings && \
+#     curl http://robotpkg.openrobots.org/packages/debian/robotpkg.asc | tee /etc/apt/keyrings/robotpkg.asc && \
+#     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/robotpkg.asc] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" | tee /etc/apt/sources.list.d/robotpkg.list && \
+#     apt-get update && \
+#     apt-get install -y --no-install-recommends \
+#     robotpkg-pinocchio && \
+#     # Clean up apt caches to keep the image small
+#     apt-get clean && \
+#     rm -rf /var/lib/apt/lists/*
+RUN wget https://github.com/frankarobotics/libfranka/releases/download/0.21.1/libfranka_0.21.1_jammy_amd64.deb
+RUN dpkg -i libfranka_0.21.1_jammy_amd64.deb
+
 RUN pip3 install -U setuptools
 RUN pip3 install -U numpy
 RUN pip3 install -U scipy

--- a/docker/mios_builder/Dockerfile
+++ b/docker/mios_builder/Dockerfile
@@ -1,16 +1,20 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y \
-    build-essential cmake git libpoco-dev libeigen3-dev libfmt-dev \
+    build-essential cmake git libpoco-dev libeigen3-dev libfmt-dev wget\
     lsb-release curl
 
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL http://robotpkg.openrobots.org/packages/debian/robotpkg.asc | tee /etc/apt/keyrings/robotpkg.asc && \
-    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/robotpkg.asc] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" | tee /etc/apt/sources.list.d/robotpkg.list
+RUN wget https://github.com/frankarobotics/libfranka/releases/download/0.21.1/libfranka_0.21.1_jammy_amd64.deb
+RUN dpkg -i libfranka_0.21.1_jammy_amd64.deb
 
 
-RUN apt-get update && apt-get install -y \
-    robotpkg-pinocchio
+# RUN mkdir -p /etc/apt/keyrings && \
+#     curl -fsSL http://robotpkg.openrobots.org/packages/debian/robotpkg.asc | tee /etc/apt/keyrings/robotpkg.asc && \
+#     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/robotpkg.asc] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg" | tee /etc/apt/sources.list.d/robotpkg.list
+
+
+# RUN apt-get update && apt-get install -y \
+#     robotpkg-pinocchio
     
 # Install Python and pip
 RUN apt-get update && apt-get install -y \

--- a/src/skill/src/skill.cpp
+++ b/src/skill/src/skill.cpp
@@ -544,7 +544,13 @@ void Skill::log_data(const Percept &p){
     }
      m_log["data_log"].push_back(
         {
+            // Kept the original format for compatibity with existing analysis scripts, but added the same data as the telemetry function
             {"time",std::chrono::duration<double>(std::chrono::high_resolution_clock::now().time_since_epoch()).count()},
+            
+            // Add the nuc timestamp in nanoseconds for easier analysis and the control box time since start for easier correlation with the control box data
+            {"nuc_timestamp", std::chrono::duration_cast<std::chrono::nanoseconds>(p->time.time_since_epoch()).count()},
+            {"control_box_time_since_start",  p->proprioception.control_box_time_since_start},
+            
             {"current_MP",m_active_mp->get_name()},
 
             {"q",mirmi_utils::from_eigen<double,7,1>(p.proprioception.q)},

--- a/src/skill/src/skill.cpp
+++ b/src/skill/src/skill.cpp
@@ -548,8 +548,8 @@ void Skill::log_data(const Percept &p){
             {"time",std::chrono::duration<double>(std::chrono::high_resolution_clock::now().time_since_epoch()).count()},
             
             // Add the nuc timestamp in nanoseconds for easier analysis and the control box time since start for easier correlation with the control box data
-            {"nuc_timestamp", std::chrono::duration_cast<std::chrono::nanoseconds>(p->time.time_since_epoch()).count()},
-            {"control_box_time_since_start",  p->proprioception.control_box_time_since_start},
+            {"nuc_timestamp", std::chrono::duration_cast<std::chrono::nanoseconds>(p.time.time_since_epoch()).count()},
+            {"control_box_time_since_start",  p.proprioception.control_box_time_since_start},
             
             {"current_MP",m_active_mp->get_name()},
 

--- a/src/telemetry/src/telemetry_udp.cpp
+++ b/src/telemetry/src/telemetry_udp.cpp
@@ -123,6 +123,10 @@ void TelemetryUDP::sending_loop(){
         for(auto sub : m_subscribers){
             // build message for every subscriber
             nlohmann::json msg_data;
+
+            msg_data["nuc_timestamp"] = std::chrono::duration_cast<std::chrono::nanoseconds>(p->time.time_since_epoch()).count();
+            msg_data["control_box_time_since_start"] = p->proprioception.control_box_time_since_start;
+
             for(std::string subscription : sub.subscriptions){
                 switch(m_data_map.find(subscription)->second){
                 case 1: mirmi_utils::write_json_array<double,4,4>(msg_data["O_T_EE"],p->proprioception.O_T_EE); break;

--- a/src/utils/include/mios/data_structures/percept.hpp
+++ b/src/utils/include/mios/data_structures/percept.hpp
@@ -108,7 +108,8 @@ public:
         double finger_width;
         double finger_temperature;
         bool is_grasping;
-
+      // Additionally, we add a timestamp to the proprioception data based on control box duration data.
+        uint64_t control_box_time_since_start;
     }proprioception;
 
     struct InternalModel{

--- a/src/utils/src/percept.cpp
+++ b/src/utils/src/percept.cpp
@@ -50,6 +50,8 @@ void Percept::update(std::unique_ptr<franka::Model> const& model, const franka::
     proprioception.finger_temperature=gripper_state.temperature;
     proprioception.is_grasping=gripper_state.is_grasped;
 
+    // Update control box time since start
+    proprioception.control_box_time_since_start=robot_state.time.toMSec();
     // Others
     robot_mode=robot_state.robot_mode;
     time = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
#### 1. Add nanosecond-resolution system timestamp
- Converts `p->time` to nanoseconds since epoch using `std::chrono`
- Provides a high-resolution, globally comparable timestamp (Unix epoch-based)

#### 2. Add control box monotonic time
- Forwards `p->proprioception.control_box_time_since_start`
- Represents internal robot runtime since system start
- Useful for control-loop analysis and relative timing
